### PR TITLE
Improved try-except for latest nim version

### DIFF
--- a/src/binnim.nim
+++ b/src/binnim.nim
@@ -57,7 +57,7 @@ proc binnim(filenames: seq[string], width: int = 20, quotes: bool = true, format
                 of "nim":
                     stdout.write " ]"
 
-    except:
+    except CatchableError:
         stderr.write_line("[ERROR] " & get_current_exception_msg() & "\n")
 
 when is_main_module:


### PR DESCRIPTION
The current code uses a bare except clause which throws a warning when compiling because the clause is deprecated, so I improved the code by adding the latest "except CatchableError" for better compatibility.